### PR TITLE
Fix stage selection and connection layer events

### DIFF
--- a/layoutboad.css
+++ b/layoutboad.css
@@ -109,7 +109,7 @@
   .endpoint{position:absolute;width:10px;height:10px;border:1px solid #2563eb;background:#fff;border-radius:50%;transform:translate(-50%, -50%);cursor:pointer; display:none;}
   .node.selected .endpoint{display:block;}
   /* コネクタ（別レイヤ） */
-  #connLayer{position:absolute; left:0; top:0; width:100%; height:100%;}
+  #connLayer{position:absolute; left:0; top:0; width:100%; height:100%; pointer-events:none;}
   .connector{pointer-events:stroke; cursor:pointer; stroke:#64748b; stroke-width:2;}
   .connector.selected{stroke:var(--sel);}
   .marquee{position:absolute;border:1px dashed #2563eb;background:rgba(37,99,235,.08);pointer-events:none;display:none}

--- a/layoutboad.js
+++ b/layoutboad.js
@@ -366,7 +366,7 @@
     function clearSelection(){ selectedNodes().forEach(function(n){ n.classList.remove('selected'); }); clearConnectorSelection(); }
 
     stage.addEventListener('pointerdown', function(e){
-      if(e.target === stage || e.target === connLayer){
+      if(e.target === stage){
         clearSelection();
         startMarquee(e);
         updateInspectorFromSelection();


### PR DESCRIPTION
## Summary
- Prevent connection layer from intercepting mouse events
- Only start selection marquee when clicking directly on stage

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check layoutboad.js`
- `npx playwright --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bfe6c45788323b64f8b534e7fb39d