### PR TITLE
Newボタンでキャンバスを初期化

### DIFF
--- a/layoutboad.js
+++ b/layoutboad.js
@@ -593,7 +593,13 @@
       };
       reader.readAsText(f, 'utf-8');
     });
-    $('#btnNew').addEventListener('click', function(){ if(confirm('現在のキャンバスを破棄してサンプルを読み込みます。よろしいですか？')){ loadSample(); setZoom(1); resetHistory(); } });
+    $('#btnNew').addEventListener('click', function(){
+      if(confirm('キャンバスを初期化しますか？')){
+        loadFrom([]);
+        setZoom(1);
+        resetHistory();
+      }
+    });
 
     /* ===== 画像保存（コネクタ矢印対応・テキスト位置補正） ===== */
     var dlgImage = $('#dlgImage');
@@ -1049,7 +1055,7 @@
       applyGrid(+gridRange.value);
       normalizeCanvasToGrid();
       updateConnLayerSize();
-      loadSample();
+      loadFrom([]);
       setZoom(1);
       resetHistory();
     })();


### PR DESCRIPTION
## Summary
- 新規作成ボタンの確認メッセージを「キャンバスを初期化しますか？」に変更
- loadSampleの呼び出しを廃止し、loadFrom([])でキャンバスとコネクタをクリア
- 初期化時も空の状態から開始するよう修正

## Testing
- `npm test` *(package.json がないため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689d39fcc3c48323825d974ac9d17988